### PR TITLE
feat: implement slash command framework

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 // indirect
 	golang.org/x/image v0.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
+github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624Y=
 github.com/sebdah/goldie/v2 v2.5.3/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvKI/NNtssI=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/pkg/commands/command.go
+++ b/pkg/commands/command.go
@@ -1,0 +1,58 @@
+package commands
+
+// Command represents a slash command that can be executed
+type Command interface {
+	// Name returns the command name (without the leading slash)
+	Name() string
+
+	// Description returns a short description shown in the command picker
+	Description() string
+
+	// Execute runs the command and returns the content to inject into the user message
+	// The first return value is the command message (e.g., "<command-message>init is analyzing your codebase…</command-message>")
+	// The second return value is the instruction content to inject
+	Execute() (commandMessage string, instructions string, err error)
+}
+
+// Registry holds all registered slash commands
+type Registry struct {
+	commands map[string]Command
+	order    []string // Preserve insertion order for display
+}
+
+// NewRegistry creates a new command registry
+func NewRegistry() *Registry {
+	return &Registry{
+		commands: make(map[string]Command),
+		order:    []string{},
+	}
+}
+
+// Register adds a command to the registry
+func (r *Registry) Register(cmd Command) {
+	name := cmd.Name()
+	if _, exists := r.commands[name]; !exists {
+		r.order = append(r.order, name)
+	}
+	r.commands[name] = cmd
+}
+
+// Get retrieves a command by name
+func (r *Registry) Get(name string) (Command, bool) {
+	cmd, ok := r.commands[name]
+	return cmd, ok
+}
+
+// List returns all registered commands in registration order
+func (r *Registry) List() []Command {
+	cmds := make([]Command, 0, len(r.order))
+	for _, name := range r.order {
+		cmds = append(cmds, r.commands[name])
+	}
+	return cmds
+}
+
+// Names returns the names of all registered commands
+func (r *Registry) Names() []string {
+	return r.order
+}

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -1,0 +1,48 @@
+package commands
+
+// InitCommand creates an AGENTS.md file following the agents.md standard
+type InitCommand struct{}
+
+// Name returns the command name
+func (c *InitCommand) Name() string {
+	return "init"
+}
+
+// Description returns a short description shown in the command picker
+func (c *InitCommand) Description() string {
+	return "Initialize AGENTS.md with codebase analysis"
+}
+
+// Execute runs the command and returns content to inject into the user message
+func (c *InitCommand) Execute() (commandMessage string, instructions string, err error) {
+	commandMessage = "<command-message>init is analyzing your codebase…</command-message>\n<command-name>/init</command-name>"
+
+	instructions = `Please analyze this codebase and create a AGENTS.md file, which will be given to future instances of John Code to operate in this repository.
+
+What to add:
+1. Commands that will be commonly used, such as how to build, lint, and run tests. Include the necessary commands to develop in this codebase, such as how to run a single test.
+2. High-level code architecture and structure so that future instances can be productive more quickly. Focus on the "big picture" architecture that requires reading multiple files to understand.
+
+Usage notes:
+- If there's already a AGENTS.md, suggest improvements to it.
+- When you make the initial AGENTS.md, do not repeat yourself and do not include obvious instructions like "Provide helpful error messages to users", "Write unit tests for all new utilities", "Never include sensitive information (API keys, tokens) in code or commits".
+- Avoid listing every component or file structure that can be easily discovered.
+- Don't include generic development practices.
+- If there are Cursor rules (in .cursor/rules/ or .cursorrules) or Copilot rules (in .github/copilot-instructions.md), make sure to include the important parts.
+- If there is a README.md, make sure to include the important parts.
+- Do not make up information such as "Common Development Tasks", "Tips for Development", "Support and Documentation" unless this is expressly included in other files that you read.
+- Be sure to prefix the file with the following text:
+
+` + "```" + `
+# AGENTS.md
+
+This file provides guidance to John Code (and other AI coding agents) when working with code in this repository.
+` + "```"
+
+	return commandMessage, instructions, nil
+}
+
+// NewInitCommand creates a new InitCommand
+func NewInitCommand() *InitCommand {
+	return &InitCommand{}
+}

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -2,14 +2,16 @@ package ui
 
 import (
 	"fmt"
-    "io/ioutil"
-    "path/filepath"
+	"io/ioutil"
+	"path/filepath"
 	"strings"
-    "time"
+	"time"
 
+	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
-    "golang.design/x/clipboard"
+	"github.com/charmbracelet/lipgloss"
+	"golang.design/x/clipboard"
 )
 
 type UI struct{}
@@ -25,10 +27,11 @@ func (u *UI) Print(msg string) {
 // Input Handling
 
 type inputModel struct {
-	textInput textinput.Model
-	err       error
-	output    string
-	canceled  bool
+	textInput    textinput.Model
+	err          error
+	output       string
+	canceled     bool
+	slashTrigger bool // Triggered when "/" is typed as first char
 }
 
 func initialInputModel(prompt string) inputModel {
@@ -59,26 +62,33 @@ func (m inputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.output = m.textInput.Value()
 			return m, tea.Quit
 		case tea.KeyCtrlC, tea.KeyEsc:
-            m.canceled = true
+			m.canceled = true
 			return m, tea.Quit
-        case tea.KeyCtrlV:
-            // Check for image data in clipboard
-            err := clipboard.Init()
-            if err == nil {
-                imageBytes := clipboard.Read(clipboard.FmtImage)
-                if len(imageBytes) > 0 {
-                    // Save to temp file
-                    tmpDir := "/tmp" // Cross platform consideration needed? For MVP /tmp is ok
-                    filename := fmt.Sprintf("john_clipboard_%d.png", time.Now().UnixNano())
-                    path := filepath.Join(tmpDir, filename)
-                    
-                    if err := ioutil.WriteFile(path, imageBytes, 0644); err == nil {
-                        m.textInput.SetValue(m.textInput.Value() + fmt.Sprintf(" [Image: %s] ", path))
-                        // Position cursor at end
-                        m.textInput.SetCursor(len(m.textInput.Value()))
-                    }
-                }
-            }
+		case tea.KeyCtrlV:
+			// Check for image data in clipboard
+			err := clipboard.Init()
+			if err == nil {
+				imageBytes := clipboard.Read(clipboard.FmtImage)
+				if len(imageBytes) > 0 {
+					// Save to temp file
+					tmpDir := "/tmp" // Cross platform consideration needed? For MVP /tmp is ok
+					filename := fmt.Sprintf("john_clipboard_%d.png", time.Now().UnixNano())
+					path := filepath.Join(tmpDir, filename)
+
+					if err := ioutil.WriteFile(path, imageBytes, 0644); err == nil {
+						m.textInput.SetValue(m.textInput.Value() + fmt.Sprintf(" [Image: %s] ", path))
+						// Position cursor at end
+						m.textInput.SetCursor(len(m.textInput.Value()))
+					}
+				}
+			}
+		case tea.KeyRunes:
+			// Check if "/" is typed as first character (empty input)
+			if len(msg.Runes) == 1 && msg.Runes[0] == '/' && m.textInput.Value() == "" {
+				m.slashTrigger = true
+				m.output = "/"
+				return m, tea.Quit
+			}
 		}
 	case error:
 		m.err = msg
@@ -178,4 +188,113 @@ func (u *UI) DisplayStream(outputChan <-chan string) {
 	if err != nil {
 		fmt.Printf("Error in stream display: %v\n", err)
 	}
+}
+
+// Command Picker for slash commands
+
+// CommandItem represents a slash command in the picker list
+type CommandItem struct {
+	name        string
+	description string
+}
+
+func (i CommandItem) Title() string       { return "/" + i.name }
+func (i CommandItem) Description() string { return i.description }
+func (i CommandItem) FilterValue() string { return i.name }
+
+type commandPickerModel struct {
+	list     list.Model
+	selected string
+	canceled bool
+}
+
+func newCommandPickerModel(commands []CommandItem) commandPickerModel {
+	items := make([]list.Item, len(commands))
+	for i, cmd := range commands {
+		items[i] = cmd
+	}
+
+	delegate := list.NewDefaultDelegate()
+	delegate.Styles.SelectedTitle = lipgloss.NewStyle().
+		Border(lipgloss.NormalBorder(), false, false, false, true).
+		BorderForeground(lipgloss.Color("62")).
+		Foreground(lipgloss.Color("170")).
+		Padding(0, 0, 0, 1)
+	delegate.Styles.SelectedDesc = lipgloss.NewStyle().
+		Border(lipgloss.NormalBorder(), false, false, false, true).
+		BorderForeground(lipgloss.Color("62")).
+		Foreground(lipgloss.Color("240")).
+		Padding(0, 0, 0, 1)
+
+	l := list.New(items, delegate, 40, 10)
+	l.Title = "Commands"
+	l.SetShowStatusBar(false)
+	l.SetFilteringEnabled(true)
+	l.Styles.Title = lipgloss.NewStyle().
+		Foreground(lipgloss.Color("170")).
+		Bold(true).
+		Padding(0, 1)
+
+	return commandPickerModel{list: l}
+}
+
+func (m commandPickerModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m commandPickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyEnter:
+			if item, ok := m.list.SelectedItem().(CommandItem); ok {
+				m.selected = item.name
+			}
+			return m, tea.Quit
+		case tea.KeyCtrlC, tea.KeyEsc:
+			m.canceled = true
+			return m, tea.Quit
+		}
+	case tea.WindowSizeMsg:
+		m.list.SetWidth(msg.Width)
+		return m, nil
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m commandPickerModel) View() string {
+	return m.list.View()
+}
+
+// CommandInfo holds command info for the picker
+type CommandInfo struct {
+	Name        string
+	Description string
+}
+
+// PickCommand displays a command picker and returns the selected command name
+// Returns empty string if canceled
+func (u *UI) PickCommand(commands []CommandInfo) string {
+	items := make([]CommandItem, len(commands))
+	for i, cmd := range commands {
+		items[i] = CommandItem{name: cmd.Name, description: cmd.Description}
+	}
+
+	p := tea.NewProgram(newCommandPickerModel(items))
+	m, err := p.Run()
+	if err != nil {
+		fmt.Printf("Error in command picker: %v\n", err)
+		return ""
+	}
+
+	if model, ok := m.(commandPickerModel); ok {
+		if model.canceled {
+			return ""
+		}
+		return model.selected
+	}
+	return ""
 }


### PR DESCRIPTION
Closes #13

## Summary
Implements a slash command framework for John Code, similar to Claude Code.

## Changes
- Added `pkg/commands/` package with Command interface and Registry
- Implemented `/init` command for AGENTS.md generation
- Added command picker UI using bubbletea list component
- Modified input handling to detect '/' and show picker immediately
- Support both '/' (picker) and '/commandname' (direct) invocation
- Increased max turns from 10 to 50 for complex tasks

## How it works
1. User types `/` → picker appears with available commands
2. User types `/init` → executes init command directly
3. Command instructions are injected into the message with `<command-message>` tags

## Testing
```bash
./john
> /      # Shows picker
> /init  # Creates AGENTS.md
```